### PR TITLE
fix:Configuration panel missing

### DIFF
--- a/package/contents/config/config.qml
+++ b/package/contents/config/config.qml
@@ -17,9 +17,9 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        *
  ***************************************************************************/
 
-import QtQuick 2.0
+import QtQuick
 
-import org.kde.plasma.configuration 2.0
+import org.kde.plasma.configuration
 
 ConfigModel {
     ConfigCategory {

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -96,6 +96,10 @@ ConfigPage {
                     property string suffix: i18n(" px")
                     value: plasmoid.configuration.fontsize
                     to: 1000
+                    property string valuews: textFromValue(value)
+                    textFromValue: function(value) {
+                        return Number(value) + suffix
+                    }
                 }
 
                 PlasmaComponents.Label {
@@ -131,6 +135,9 @@ ConfigPage {
                     from: 0
                     to: 100
                     stepSize: 1
+                    textFromValue: function(value) {
+                        return Number(value) + suffix
+                    }
                 }
 
                 PlasmaComponents.Label {

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -1,8 +1,8 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Layouts 1.0
-import QtQuick.Dialogs 1.2
-import org.kde.plasma.components 2.0 as PlasmaComponents
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Dialogs
+import org.kde.plasma.components as PlasmaComponents
 
 import ".."
 
@@ -93,9 +93,9 @@ ConfigPage {
 
                 SpinBox {
                     id: fontsize
-                    suffix: i18n(" px")
+                    property string suffix: i18n(" px")
                     value: plasmoid.configuration.fontsize
-                    maximumValue: 1000
+                    to: 1000
                 }
 
                 PlasmaComponents.Label {
@@ -127,9 +127,9 @@ ConfigPage {
                 SpinBox {
                     id: opacity_spin
                     value: plasmoid.configuration.opacity
-                    suffix: i18n(" %")
-                    minimumValue: 0
-                    maximumValue: 100
+                    property string suffix: i18n(" %")
+                    from: 0
+                    to: 100
                     stepSize: 1
                 }
 

--- a/package/contents/ui/config/ConfigPage.qml
+++ b/package/contents/ui/config/ConfigPage.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.0
-import QtQuick.Layouts 1.0
+import QtQuick
+import QtQuick.Layouts
 
 ColumnLayout {
     id: page

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -17,8 +17,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        *
  ***************************************************************************/
 
-import QtQuick 2.15
-import QtQuick.Layouts 1.1
+import QtQuick
+import QtQuick.Layouts
 import QtQuick.Controls
 
 import org.kde.plasma.plasmoid


### PR DESCRIPTION
The properties of SpinBox has been changed in Qt6,  so the general configuration panel will fail with unknown properties. Here is the resolution. 